### PR TITLE
fix: desactiver build command netlify pour eviter erreur flutter

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-  # Publier depuis le dossier releases/current (lien symlink vers la dernière version)
+  # Pas de build command - on publie depuis releases/current (pré-compilé)
+  command = ""
   publish = "releases/current"
 
 [context.production]


### PR DESCRIPTION
This pull request makes a minor update to the Netlify configuration. The build command is now explicitly set to an empty string, clarifying that the site is published from the pre-compiled `releases/current` directory without running a build step.