### PR TITLE
Corriger: Exclure les années avec zéro contributions du graphique

### DIFF
--- a/netlify/functions/github-stats.js
+++ b/netlify/functions/github-stats.js
@@ -170,13 +170,15 @@ async function calculateContributionsByYear(contributionData) {
     });
   }
 
-  // Ajouter l'année actuelle si elle n'existe pas
-  const currentYear = new Date().getFullYear();
-  if (!byYear[currentYear]) {
-    byYear[currentYear] = 0;
-  }
+  // Filtrer pour exclure les années avec zéro contributions
+  const filteredByYear = {};
+  Object.entries(byYear).forEach(([year, count]) => {
+    if (count > 0) {
+      filteredByYear[year] = count;
+    }
+  });
 
-  return byYear;
+  return filteredByYear;
 }
 
 async function calculateThisYearContributions(contributionsByYear) {


### PR DESCRIPTION
This pull request updates the contribution calculation logic in `github-stats.js` to improve the accuracy of yearly contribution data. The main change is to exclude years with zero contributions from the returned results, rather than including the current year with a zero count.

Contribution data filtering:

* Modified `calculateContributionsByYear` to filter out years with zero contributions, ensuring only years with actual contributions are included in the output.
* Removed logic that explicitly added the current year with a zero count if there were no contributions, preventing unnecessary zero-value entries in the results.